### PR TITLE
FFMPEG `h264`, `h265/hevc` decoder 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ find_package(catkin REQUIRED
   camera_info_manager
   cv_bridge
   dynamic_reconfigure
+  ffmpeg_image_transport
   image_geometry
   image_transport
   message_filters
@@ -104,6 +105,7 @@ catkin_package(
   camera_info_manager
   cv_bridge
   dynamic_reconfigure
+  ffmpeg_image_transport
   image_geometry
   image_transport
   message_filters

--- a/include/orbbec_camera/ob_camera_node.h
+++ b/include/orbbec_camera/ob_camera_node.h
@@ -86,6 +86,8 @@ class OBCameraNode {
 
   std::shared_ptr<ob::Frame> softwareDecodeColorFrame(const std::shared_ptr<ob::Frame>& frame);
 
+  void setupFfmpegDecoder();
+
   void ffmpegDecoderCallback(const sensor_msgs::ImageConstPtr &img,
                              bool isKeyFrame);
 
@@ -399,6 +401,7 @@ class OBCameraNode {
   // ffmpeg (h264, h265, hevc) decoder
   std::shared_ptr<ffmpeg_image_transport::FFMPEGDecoder> ffmpeg_decoder_ = nullptr;
   ffmpeg_image_transport::FFMPEGPacket::Ptr ffmpeg_pkt_ = nullptr;
+  boost::function<void (const sensor_msgs::ImageConstPtr &, bool)> ffmpeg_decoder_callback_;
 };
 
 }  // namespace orbbec_camera

--- a/include/orbbec_camera/ob_camera_node.h
+++ b/include/orbbec_camera/ob_camera_node.h
@@ -21,6 +21,7 @@
 #include "ros/ros.h"
 #include <opencv2/opencv.hpp>
 #include <cv_bridge/cv_bridge.h>
+#include <ffmpeg_image_transport/ffmpeg_decoder.h>
 #include <sensor_msgs/CameraInfo.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <sensor_msgs/distortion_models.h>
@@ -84,6 +85,9 @@ class OBCameraNode {
   void readDefaultWhiteBalance();
 
   std::shared_ptr<ob::Frame> softwareDecodeColorFrame(const std::shared_ptr<ob::Frame>& frame);
+
+  void ffmpegDecoderCallback(const sensor_msgs::ImageConstPtr &img,
+                             bool isKeyFrame);
 
   void onNewFrameCallback(const std::shared_ptr<ob::Frame>& frame,
                           const stream_index_pair& stream_index);
@@ -391,6 +395,10 @@ class OBCameraNode {
   // double infrared
   bool enable_left_ir_ = false;
   bool enable_right_ir_ = false;
+
+  // ffmpeg (h264, h265, hevc) decoder
+  std::shared_ptr<ffmpeg_image_transport::FFMPEGDecoder> ffmpeg_decoder_ = nullptr;
+  ffmpeg_image_transport::FFMPEGPacket::Ptr ffmpeg_pkt_ = nullptr;
 };
 
 }  // namespace orbbec_camera

--- a/package.xml
+++ b/package.xml
@@ -10,6 +10,7 @@
     <depend>camera_info_manager</depend>
     <depend>cv_bridge</depend>
     <depend>dynamic_reconfigure</depend>
+    <depend>ffmpeg_image_transport</depend>
     <depend>image_geometry</depend>
     <depend>image_transport</depend>
     <depend>libudev-dev</depend>

--- a/src/ob_camera_node.cpp
+++ b/src/ob_camera_node.cpp
@@ -60,11 +60,17 @@ void OBCameraNode::init() {
 #endif
   if (format_[COLOR] == OB_FORMAT_H264) {
     ffmpeg_decoder_ = std::make_shared<ffmpeg_image_transport::FFMPEGDecoder>();
+    ffmpeg_pkt_ = boost::make_shared<ffmpeg_image_transport::FFMPEGPacket>();
     ffmpeg_pkt_->encoding = "h264_nvenc";
     ffmpeg_pkt_->img_width = width_[COLOR];
     ffmpeg_pkt_->img_height = height_[COLOR];
-    ffmpeg_decoder_->initialize(ffmpeg_pkt_, 
+    bool success = ffmpeg_decoder_->initialize(ffmpeg_pkt_, 
       boost::bind(&OBCameraNode::ffmpegDecoderCallback, this, boost::placeholders::_1, boost::placeholders::_2));
+    if (!success) {
+      ROS_ERROR_STREAM("Failed to initialize FFMPEGDecoder but color format is set to H264! Exiting...");
+      throw;
+    }
+    encoding_[COLOR] = sensor_msgs::image_encodings::BGR8;
   }
   rgb_buffer_ = new uint8_t[width_[COLOR] * height_[COLOR] * 3];
   rgb_is_decoded_ = false;
@@ -730,7 +736,7 @@ bool OBCameraNode::decodeColorFrameToBuffer(const std::shared_ptr<ob::Frame>& fr
     {
       auto *data = static_cast<uint8_t *>(frame->data());
       ffmpeg_pkt_->data.assign(data, data + frame->dataSize());
-      ROS_ERROR_STREAM("Attempting to decode frame with size " << frame->dataSize());
+      ROS_DEBUG_STREAM("Attempting to decode frame with size " << frame->dataSize());
       if (!ffmpeg_decoder_->isInitialized() || !ffmpeg_decoder_->decodePacket(ffmpeg_pkt_)) {
         ROS_ERROR_STREAM("Decode frame via FFMPEG failed");
       } else {

--- a/src/ob_camera_node.cpp
+++ b/src/ob_camera_node.cpp
@@ -1057,7 +1057,7 @@ void OBCameraNode::imageUnsubscribedCallback(const stream_index_pair& stream_ind
       }
     }
     if (all_stream_no_subscriber) {
-      stopStreams();
+      // stopStreams();
     }
   } else {
     if (!stream_started_[stream_index]) {

--- a/src/ob_camera_node.cpp
+++ b/src/ob_camera_node.cpp
@@ -58,10 +58,12 @@ void OBCameraNode::init() {
 #elif defined(USE_NV_HW_DECODER)
   mjpeg_decoder_ = std::make_shared<JetsonNvJPEGDecoder>(width_[COLOR], height_[COLOR]);
 #endif
-  if (format_[COLOR] == OB_FORMAT_H264) {
+  if (format_[COLOR] == OB_FORMAT_H264 || 
+      format_[COLOR] == OB_FORMAT_H265 ||
+      format_[COLOR] == OB_FORMAT_HEVC) {
     ffmpeg_decoder_ = std::make_shared<ffmpeg_image_transport::FFMPEGDecoder>();
     ffmpeg_pkt_ = boost::make_shared<ffmpeg_image_transport::FFMPEGPacket>();
-    ffmpeg_pkt_->encoding = "h264_nvenc";
+    ffmpeg_pkt_->encoding = format_[COLOR] == OB_FORMAT_H264 ? "h264_nvenc" : "hevc_nvenc";
     ffmpeg_pkt_->img_width = width_[COLOR];
     ffmpeg_pkt_->img_height = height_[COLOR];
     bool success = ffmpeg_decoder_->initialize(ffmpeg_pkt_, 


### PR DESCRIPTION
This PR requires https://github.com/BastianSolutionsRandD/ffmpeg_image_transport/pull/1

* Adds ability to decode H264/H265 frames from Femto Mega camera
* Uses GPU acceleration
* Decoder goes idle when there is no subscriber, saving compute resources